### PR TITLE
Request sentiment analysis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -119,3 +119,17 @@ libdfegrpc-$(VERSION)-1.x86_64.rpm libdfegrpc-devel-$(VERSION)-1.x86_64.rpm: Mak
 			-v $(CURDIR):/out \
 			-w /tmp libdfegrpc_build \
 			make -f /src/Makefile.dfedocker
+
+.PHONY = docker-test
+docker-test: docker-build
+	docker run --rm -v $(CURDIR):/src:ro \
+			-e VERSION=$(VERSION) \
+			-e COFFEE_SHOP_KEY_PATH=$(COFFEE_SHOP_KEY_PATH) \
+			-e COFFEE_SHOP_PROJECT_ID=$(COFFEE_SHOP_PROJECT_ID) \
+			libdfegrpc_build \
+			make -C /src run-test
+
+.PHONY = run-test
+run-test:
+		rpm -ivh $(RPMS)
+		dfegrpc_test_client -a coffee_please.ul -k $(COFFEE_SHOP_KEY_PATH) -p $(COFFEE_SHOP_PROJECT_ID)

--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,8 @@ libgrpc-$(GRPC_VERSION)-1.x86_64.rpm libgrpc-devel-$(GRPC_VERSION)-1.x86_64.rpm:
 libdfegrpc-$(VERSION)-1.x86_64.rpm libdfegrpc-devel-$(VERSION)-1.x86_64.rpm: Makefile.dfedocker \
 															libgrpc-$(GRPC_VERSION)-1.x86_64.rpm \
 															libgrpc-devel-$(GRPC_VERSION)-1.x86_64.rpm \
-															.build/libdfegrpc_build
+															.build/libdfegrpc_build \
+															libdfegrpc.cc libdfegrpc.h libdfegrpc_internal.h
 	docker run --rm -v $(CURDIR):/src:ro \
 			-e VERSION=$(VERSION) \
 			-v $(CURDIR):/out \

--- a/libdfegrpc.cc
+++ b/libdfegrpc.cc
@@ -364,7 +364,8 @@ template<typename T> static void make_audio_result(struct dialogflow_session *se
 static void log_responses(struct dialogflow_session *session, int score)
 {
     size_t response_count = session->results.size();
-    struct dialogflow_log_data log_data[response_count + 1 /* for score */];
+    size_t log_data_size = response_count + 1; /* for score */
+    struct dialogflow_log_data log_data[log_data_size];
     size_t i;
     std::string score_string = std::to_string(score);
 
@@ -380,7 +381,7 @@ static void log_responses(struct dialogflow_session *session, int score)
         }
     }
 
-    df_log_call(session->user_data, "results", response_count, log_data);
+    df_log_call(session->user_data, "results", log_data_size, log_data);
 }
 
 static void make_streaming_responses(struct dialogflow_session *session)

--- a/libdfegrpc.h
+++ b/libdfegrpc.h
@@ -52,6 +52,7 @@ extern LIBDFEGRPC_DLL_EXPORTED int df_set_session_id(struct dialogflow_session *
 extern LIBDFEGRPC_DLL_EXPORTED const char *df_get_session_id(struct dialogflow_session *session);
 extern LIBDFEGRPC_DLL_EXPORTED int df_set_project_id(struct dialogflow_session *session, const char *project_id);
 extern LIBDFEGRPC_DLL_EXPORTED const char *df_get_project_id(struct dialogflow_session *session);
+extern LIBDFEGRPC_DLL_EXPORTED int df_set_request_sentiment_analysis(struct dialogflow_session *session, int request_sentiment_analysis);
 extern LIBDFEGRPC_DLL_EXPORTED int df_recognize_event(struct dialogflow_session *session, const char *event, const char *language, int request_audio);
 extern LIBDFEGRPC_DLL_EXPORTED int df_start_recognition(struct dialogflow_session *session, const char *language, int request_audio);
 extern LIBDFEGRPC_DLL_EXPORTED int df_stop_recognition(struct dialogflow_session *session);

--- a/libdfegrpc_internal.h
+++ b/libdfegrpc_internal.h
@@ -52,6 +52,7 @@ struct dialogflow_session {
     size_t bytesWritten;
     size_t packetsWritten;
     int responsesReceived;
+    bool request_sentiment_analysis;
     bool debug;
     void *user_data;
 };

--- a/test_client.c
+++ b/test_client.c
@@ -150,6 +150,8 @@ int main(int argc, char *argv[])
             return 15;
         }
 
+        df_set_request_sentiment_analysis(session, 1);
+
         if (df_start_recognition(session, NULL, 0)) {
             test_log(LOG_ERROR, "Error starting recognition\n");
             return 50;


### PR DESCRIPTION
Add API functions to enable the requesting of sentiment analysis from dialogflow and then pull the semantic responses into result items.

Fix an off-by-one error in the response logging code.