### PR TITLE
Stop request on final transcript

### DIFF
--- a/libdfegrpc.h
+++ b/libdfegrpc.h
@@ -80,6 +80,7 @@ extern LIBDFEGRPC_DLL_EXPORTED void df_set_debug(struct dialogflow_session *sess
 extern LIBDFEGRPC_DLL_EXPORTED struct timeval df_get_session_start_time(struct dialogflow_session *session);
 extern LIBDFEGRPC_DLL_EXPORTED struct timeval df_get_session_last_transcription_time(struct dialogflow_session *session);
 extern LIBDFEGRPC_DLL_EXPORTED struct timeval df_get_session_intent_detected_time(struct dialogflow_session *session);
+extern LIBDFEGRPC_DLL_EXPORTED void df_set_stop_writes_on_final_transcription(struct dialogflow_session *session, int stop_writes);
 
 extern LIBDFEGRPC_DLL_EXPORTED int google_synth_speech(const char *endpoint, const char *svc_key, const char *text, 
     const char *language, const char *voice_name, const char *destination_filename);

--- a/libdfegrpc_internal.h
+++ b/libdfegrpc_internal.h
@@ -57,6 +57,8 @@ struct dialogflow_session {
     bool request_sentiment_analysis;
     bool use_external_endpointer;
     bool debug;
+    bool stop_writes_on_final_transcription;
+    bool writes_done;
     void *user_data;
     timeval session_start_time;
     timeval last_transcription_time;

--- a/test_client.c
+++ b/test_client.c
@@ -160,6 +160,7 @@ int main(int argc, char *argv[])
         df_set_session_id(session, "testclient");
         df_set_debug(session, 1);
         df_set_use_external_endpointer(session, !single_utterance);
+        df_set_stop_writes_on_final_transcription(session, 1);
         if (model) {
             df_set_model(session, model);
         }
@@ -193,11 +194,14 @@ int main(int argc, char *argv[])
 
             test_log(LOG_DEBUG, "Recognition started -- %d\n", df_get_rpc_state(session));
 
-            while (!feof(audio) && !ferror(audio)) {
+            while (!ferror(audio)) {
                 enum dialogflow_session_state state;
                 char buffer[160];
                 int newResponseCount;
-                size_t read = fread(buffer, sizeof(char), sizeof(buffer), audio);
+                size_t read = 0;
+                if (!feof(audio)) {
+                    read = fread(buffer, sizeof(char), sizeof(buffer), audio);
+                }
                 if (read < sizeof(buffer)) {
                     memset(buffer + read, 0x7f, sizeof(buffer) - read);
                 }


### PR DESCRIPTION
When a final transcription message is received, shut down the send stream (if so configured). This will indicate to dialogflow that we are finished and are waiting on a response.