### PR TITLE
El7 updates

### DIFF
--- a/Dockerfile.el6
+++ b/Dockerfile.el6
@@ -1,4 +1,5 @@
 FROM centos:6
+
 LABEL maintainer="daniel.collins@usan.com"
 
 RUN curl -L http://people.centos.org/tru/devtools-2/devtools-2.repo > /etc/yum.repos.d/devtools-2.repo && \
@@ -10,21 +11,21 @@ RUN yum install -y \
     devtoolset-2-gcc \
     devtoolset-2-gcc-c++ \
     gcc \
+    gem \
     git \
     make \
     libtool \
     rpm-build \
-    ruby193 \
-    ruby193-ruby-devel \
-    ruby-gems \
+    rh-ruby23 \
+    rh-ruby23-ruby-devel \
     wget
 
-# Enables DevToolset-2 and ruby193
-ENV PATH /opt/rh/devtoolset-2/root/usr/bin:/opt/rh/ruby193/root/usr/bin:$PATH
+# Enables DevToolset-2 and ruby 2.3
+ENV PATH /opt/rh/devtoolset-2/root/usr/bin:/opt/rh/rh-ruby23/root/usr/bin:$PATH
 ENV MANPATH /opt/rh/devtoolset-2/root/usr/share/man
 ENV INFOPATH /opt/rh/devtoolset-2/root/usr/share/info
 ENV PCP_DIR /opt/rh/devtoolset-2/root
-ENV LD_LIBRARY_PATH /opt/rh/devtoolset-2/root/usr/lib64:/opt/rh/devtoolset-2/root/usr/lib:/opt/rh/ruby193/root/usr/lib64:/opt/rh/ruby193/root/usr/lib
+ENV LD_LIBRARY_PATH /opt/rh/devtoolset-2/root/usr/lib64:/opt/rh/devtoolset-2/root/usr/lib:/opt/rh/rh-ruby23/root/usr/lib64:/opt/rh/rh-ruby23/root/usr/lib
 
 ENV GEM_HOME=/usr
 ENV GEM_PATH=/usr

--- a/Dockerfile.el7
+++ b/Dockerfile.el7
@@ -1,16 +1,18 @@
-FROM centos:6
+FROM centos:7
 
 LABEL maintainer="daniel.collins@usan.com"
 
-RUN curl -L http://people.centos.org/tru/devtools-2/devtools-2.repo > /etc/yum.repos.d/devtools-2.repo && \
-    yum install -y centos-release-scl
+RUN yum install -y centos-release-scl
+
+RUN yum install -y devtoolset-7
+
+RUN scl enable devtoolset-7 bash
 
 RUN yum install -y \
     autoconf \
-    devtoolset-2-binutils \
-    devtoolset-2-gcc \
-    devtoolset-2-gcc-c++ \
+    binutils \
     gcc \
+    gcc-c++ \
     gem \
     git \
     make \
@@ -20,12 +22,9 @@ RUN yum install -y \
     rh-ruby23-ruby-devel \
     wget
 
-# Enables DevToolset-2 and ruby 2.3
-ENV PATH /opt/rh/devtoolset-2/root/usr/bin:/opt/rh/rh-ruby23/root/usr/bin:$PATH
-ENV MANPATH /opt/rh/devtoolset-2/root/usr/share/man
-ENV INFOPATH /opt/rh/devtoolset-2/root/usr/share/info
-ENV PCP_DIR /opt/rh/devtoolset-2/root
-ENV LD_LIBRARY_PATH /opt/rh/devtoolset-2/root/usr/lib64:/opt/rh/devtoolset-2/root/usr/lib:/opt/rh/rh-ruby23/root/usr/lib64:/opt/rh/rh-ruby23/root/usr/lib
+# Enables ruby 2.3 and installs fpm
+ENV PATH /opt/rh/rh-ruby23/root/usr/bin:$PATH
+ENV LD_LIBRARY_PATH /opt/rh/rh-ruby23/root/usr/lib64:/opt/rh/rh-ruby23/root/usr/lib
 
 ENV GEM_HOME=/usr
 ENV GEM_PATH=/usr

--- a/Dockerfile.el7
+++ b/Dockerfile.el7
@@ -1,0 +1,33 @@
+FROM centos:6
+
+LABEL maintainer="daniel.collins@usan.com"
+
+RUN curl -L http://people.centos.org/tru/devtools-2/devtools-2.repo > /etc/yum.repos.d/devtools-2.repo && \
+    yum install -y centos-release-scl
+
+RUN yum install -y \
+    autoconf \
+    devtoolset-2-binutils \
+    devtoolset-2-gcc \
+    devtoolset-2-gcc-c++ \
+    gcc \
+    gem \
+    git \
+    make \
+    libtool \
+    rpm-build \
+    rh-ruby23 \
+    rh-ruby23-ruby-devel \
+    wget
+
+# Enables DevToolset-2 and ruby 2.3
+ENV PATH /opt/rh/devtoolset-2/root/usr/bin:/opt/rh/rh-ruby23/root/usr/bin:$PATH
+ENV MANPATH /opt/rh/devtoolset-2/root/usr/share/man
+ENV INFOPATH /opt/rh/devtoolset-2/root/usr/share/info
+ENV PCP_DIR /opt/rh/devtoolset-2/root
+ENV LD_LIBRARY_PATH /opt/rh/devtoolset-2/root/usr/lib64:/opt/rh/devtoolset-2/root/usr/lib:/opt/rh/rh-ruby23/root/usr/lib64:/opt/rh/rh-ruby23/root/usr/lib
+
+ENV GEM_HOME=/usr
+ENV GEM_PATH=/usr
+
+RUN gem install --no-ri --no-rdoc fpm

--- a/Makefile.dfedocker
+++ b/Makefile.dfedocker
@@ -1,25 +1,29 @@
 VERSION ?= $(shell git describe --tags --dirty=M 2> /dev/null | sed -e 's/[^/]*\///g' -e 's/-/_/g')
-GRPC_RELEASE ?= 1.12.1
+GRPC_RELEASE ?= 1.12.x
 PROTOBUF_RELEASE ?= 3.5.1
 
 .PHONY: all
-all: libdfegrpc-$(VERSION)-1.x86_64.rpm libdfegrpc-devel-$(VERSION)-1.x86_64.rpm
+all: $(LIBDFEGRPC_RPM) $(LIBDFEGRPC_DEVEL_RPM)
 	cp $^ /out
 
-libdfegrpc-$(VERSION)-1.x86_64.rpm: /usr/lib/libdfegrpc.so 
-	fpm -s dir -t rpm -n libdfegrpc -v $(VERSION) \
+$(LIBDFEGRPC_RPM): /usr/lib/libdfegrpc.so 
+	fpm --input-type dir --output-type rpm --name libdfegrpc --version $(VERSION) \
 		--after-install /src/ldconfig.sh \
 		--after-upgrade /src/ldconfig.sh \
-		-d 'libgrpc > 1' \
+		--rpm-dist $(DISTRIBUTION) \
+		--iteration $(ITERATION) \
+		--depends 'libgrpc > 1' \
 		/usr/include/libdfegrpc.h \
 		/usr/lib/libdfegrpc.so \
 		test_client=/usr/bin/dfegrpc_test_client \
 		test_synth=/usr/bin/dfegrpc_test_synth
 
-libdfegrpc-devel-$(VERSION)-1.x86_64.rpm: /usr/lib/libdfegrpc.so
-	fpm -s dir -t rpm -n libdfegrpc-devel -v $(VERSION) \
-		-d 'libdfegrpc > 1' \
-		-d 'libgrpc-devel > 1' \
+$(LIBDFEGRPC_DEVEL_RPM): /usr/lib/libdfegrpc.so
+	fpm --input-type dir --output-type rpm --name libdfegrpc-devel --version $(VERSION) \
+		--rpm-dist $(DISTRIBUTION) \
+		--iteration $(ITERATION) \
+		--depends 'libdfegrpc > 1' \
+		--depends 'libgrpc-devel > 1' \
 		/usr/include/libdfegrpc.h 
 
 /usr/lib/libdfegrpc.so: /src/Makefile /usr/lib/libprotobuf.so
@@ -30,5 +34,5 @@ libdfegrpc-devel-$(VERSION)-1.x86_64.rpm: /usr/lib/libdfegrpc.so
 	make test
 
 /usr/lib/libprotobuf.so:
-	rpm -ivh /src/libgrpc-$(GRPC_RELEASE)-1.x86_64.rpm
-	rpm -ivh /src/libgrpc-devel-$(GRPC_RELEASE)-1.x86_64.rpm
+	rpm -ivh /src/$(LIBGRPC_RPM)
+	rpm -ivh /src/$(LIBGRPC_DEVEL_RPM)

--- a/Makefile.dockerbuild
+++ b/Makefile.dockerbuild
@@ -18,47 +18,50 @@ all: $(RPMS)
 .build:
 	mkdir -p $@
 
-.build/libdfegrpc_build: Dockerfile.$(DISTRIBUTION) .build
-	docker build -f Dockerfile.$(DISTRIBUTION) --tag libdfegrpc_build:latest .
+.build/libdfegrpc_build.$(DISTRIBUTION): Dockerfile.$(DISTRIBUTION) .build
+	docker build -f Dockerfile.$(DISTRIBUTION) --tag libdfegrpc_build:latest.$(DISTRIBUTION) .
 	@touch "$@"
 
-$(LIBGRPC_RPM) $(LIBGRPC_DEVEL_RPM): Makefile.grpcdocker .build/libdfegrpc_build
-	docker run --rm -v $(CURDIR):/src:ro \
-			-v $(CURDIR):/out \
-			-e ITERATION=$(ITERATION) \
-			-e DISTRIBUTION=$(DISTRIBUTION) \
-			-e LIBGRPC_RPM=$(LIBGRPC_RPM) \
-			-e LIBGRPC_DEVEL_RPM=$(LIBGRPC_DEVEL_RPM) \
-			-w /tmp \
-			libdfegrpc_build \
-			make -f /src/Makefile.grpcdocker
+$(LIBGRPC_RPM) $(LIBGRPC_DEVEL_RPM): Makefile.grpcdocker .build/libdfegrpc_build.$(DISTRIBUTION)
+	docker run --rm \
+	       	--volume $(CURDIR):/src:ro \
+		--volume $(CURDIR):/out \
+		--env ITERATION=$(ITERATION) \
+		--env DISTRIBUTION=$(DISTRIBUTION) \
+		--env LIBGRPC_RPM=$(LIBGRPC_RPM) \
+		--env LIBGRPC_DEVEL_RPM=$(LIBGRPC_DEVEL_RPM) \
+		--workdir /tmp \
+		libdfegrpc_build:latest.$(DISTRIBUTION) \
+		make -f /src/Makefile.grpcdocker
 
 $(LIBDFEGRPC_RPM) $(LIBDFEGRPC_DEVEL_RPM): Makefile.dfedocker \
 	$(LIBGRPC_RPM) \
 	$(LIBGRPC_DEVEL_RPM) \
-	.build/libdfegrpc_build \
+	.build/libdfegrpc_build.$(DISTRIBUTION) \
 	libdfegrpc.cc libdfegrpc.h libdfegrpc_internal.h
-	docker run --rm -v $(CURDIR):/src:ro \
-			-v $(CURDIR):/out \
-			-e VERSION=$(VERSION) \
-			-e ITERATION=$(ITERATION) \
-			-e DISTRIBUTION=$(DISTRIBUTION) \
-			-e LIBGRPC_RPM=$(LIBGRPC_RPM) \
-			-e LIBGRPC_DEVEL_RPM=$(LIBGRPC_DEVEL_RPM) \
-			-e LIBDFEGRPC_RPM=$(LIBDFEGRPC_RPM) \
-			-e LIBDFEGRPC_DEVEL_RPM=$(LIBDFEGRPC_DEVEL_RPM) \
-			-w /tmp \
-			libdfegrpc_build \
-			make -f /src/Makefile.dfedocker
+	docker run --rm \
+		--volume $(CURDIR):/src:ro \
+		--volume $(CURDIR):/out \
+		--env VERSION=$(VERSION) \
+		--env ITERATION=$(ITERATION) \
+		--env DISTRIBUTION=$(DISTRIBUTION) \
+		--env LIBGRPC_RPM=$(LIBGRPC_RPM) \
+		--env LIBGRPC_DEVEL_RPM=$(LIBGRPC_DEVEL_RPM) \
+		--env LIBDFEGRPC_RPM=$(LIBDFEGRPC_RPM) \
+		--env LIBDFEGRPC_DEVEL_RPM=$(LIBDFEGRPC_DEVEL_RPM) \
+		--workdir /tmp \
+		libdfegrpc_build:latest.$(DISTRIBUTION) \
+		make -f /src/Makefile.dfedocker
 
 .PHONY: docker-test
 docker-test: docker-build
-	docker run --rm -v $(CURDIR):/src:ro \
-			-e VERSION=$(VERSION) \
-			-e COFFEE_SHOP_KEY_PATH=$(COFFEE_SHOP_KEY_PATH) \
-			-e COFFEE_SHOP_PROJECT_ID=$(COFFEE_SHOP_PROJECT_ID) \
-			libdfegrpc_build \
-			make -C /src run-test
+	docker run --rm \
+		--volume $(CURDIR):/src:ro \
+		--env VERSION=$(VERSION) \
+		--env COFFEE_SHOP_KEY_PATH=$(COFFEE_SHOP_KEY_PATH) \
+		--env COFFEE_SHOP_PROJECT_ID=$(COFFEE_SHOP_PROJECT_ID) \
+		libdfegrpc_build:latest.$(DISTRIBUTION) \
+		make -C /src run-test
 
 .PHONY: run-test
 run-test:

--- a/Makefile.dockerbuild
+++ b/Makefile.dockerbuild
@@ -3,28 +3,28 @@ GRPC_VERSION ?= 1.12.x
 
 ARCH = $(shell uname -m)
 ITERATION = 1
-DISTRIBUTION = el6
+DISTRIBUTION ?= el6
 
 LIBGRPC_RPM = libgrpc-$(GRPC_VERSION)-$(ITERATION).$(DISTRIBUTION).$(ARCH).rpm
 LIBGRPC_DEVEL_RPM = libgrpc-devel-$(GRPC_VERSION)-$(ITERATION).$(DISTRIBUTION).$(ARCH).rpm
-LIBDFEGRPC_RPM = libdfegrpc-$(VERSION)-$(ITERATION).$(DISTRIBUTION).$(ARCH).rpm 
+LIBDFEGRPC_RPM = libdfegrpc-$(VERSION)-$(ITERATION).$(DISTRIBUTION).$(ARCH).rpm
 LIBDFEGRPC_DEVEL_RPM = libdfegrpc-devel-$(VERSION)-$(ITERATION).$(DISTRIBUTION).$(ARCH).rpm
 
 RPMS = $(LIBGRPC_RPM) $(LIBGRPC_DEVEL_RPM) $(LIBDFEGRPC_RPM) $(LIBDFEGRPC_DEVEL_RPM)
 
 .PHONY: all
 all: $(RPMS)
-
+	
 .build:
 	mkdir -p $@
 
 .build/libdfegrpc_build.$(DISTRIBUTION): Dockerfile.$(DISTRIBUTION) .build
-	docker build -f Dockerfile.$(DISTRIBUTION) --tag libdfegrpc_build:latest.$(DISTRIBUTION) .
+	docker build --file Dockerfile.$(DISTRIBUTION) --tag libdfegrpc_build:latest.$(DISTRIBUTION) .
 	@touch "$@"
 
 $(LIBGRPC_RPM) $(LIBGRPC_DEVEL_RPM): Makefile.grpcdocker .build/libdfegrpc_build.$(DISTRIBUTION)
 	docker run --rm \
-	       	--volume $(CURDIR):/src:ro \
+		--volume $(CURDIR):/src:ro \
 		--volume $(CURDIR):/out \
 		--env ITERATION=$(ITERATION) \
 		--env DISTRIBUTION=$(DISTRIBUTION) \
@@ -34,11 +34,9 @@ $(LIBGRPC_RPM) $(LIBGRPC_DEVEL_RPM): Makefile.grpcdocker .build/libdfegrpc_build
 		libdfegrpc_build:latest.$(DISTRIBUTION) \
 		make -f /src/Makefile.grpcdocker
 
-$(LIBDFEGRPC_RPM) $(LIBDFEGRPC_DEVEL_RPM): Makefile.dfedocker \
-	$(LIBGRPC_RPM) \
-	$(LIBGRPC_DEVEL_RPM) \
-	.build/libdfegrpc_build.$(DISTRIBUTION) \
-	libdfegrpc.cc libdfegrpc.h libdfegrpc_internal.h
+$(LIBDFEGRPC_RPM) $(LIBDFEGRPC_DEVEL_RPM): Makefile.dfedocker .build/libdfegrpc_build.$(DISTRIBUTION) \
+	libdfegrpc.cc libdfegrpc.h libdfegrpc_internal.h \
+	$(LIBGRPC_RPM) $(LIBGRPC_DEVEL_RPM)
 	docker run --rm \
 		--volume $(CURDIR):/src:ro \
 		--volume $(CURDIR):/out \
@@ -54,7 +52,7 @@ $(LIBDFEGRPC_RPM) $(LIBDFEGRPC_DEVEL_RPM): Makefile.dfedocker \
 		make -f /src/Makefile.dfedocker
 
 .PHONY: docker-test
-docker-test: docker-build
+docker-test: all
 	docker run --rm \
 		--volume $(CURDIR):/src:ro \
 		--env VERSION=$(VERSION) \

--- a/Makefile.dockerbuild
+++ b/Makefile.dockerbuild
@@ -1,0 +1,66 @@
+VERSION ?= $(shell git describe --tags --dirty=M 2> /dev/null | sed -e 's/[^/]*\///g' -e 's/-/_/g')
+GRPC_VERSION ?= 1.12.x
+
+ARCH = $(shell uname -m)
+ITERATION = 1
+DISTRIBUTION = el6
+
+LIBGRPC_RPM = libgrpc-$(GRPC_VERSION)-$(ITERATION).$(DISTRIBUTION).$(ARCH).rpm
+LIBGRPC_DEVEL_RPM = libgrpc-devel-$(GRPC_VERSION)-$(ITERATION).$(DISTRIBUTION).$(ARCH).rpm
+LIBDFEGRPC_RPM = libdfegrpc-$(VERSION)-$(ITERATION).$(DISTRIBUTION).$(ARCH).rpm 
+LIBDFEGRPC_DEVEL_RPM = libdfegrpc-devel-$(VERSION)-$(ITERATION).$(DISTRIBUTION).$(ARCH).rpm
+
+RPMS = $(LIBGRPC_RPM) $(LIBGRPC_DEVEL_RPM) $(LIBDFEGRPC_RPM) $(LIBDFEGRPC_DEVEL_RPM)
+
+.PHONY: all
+all: $(RPMS)
+
+.build:
+	mkdir -p $@
+
+.build/libdfegrpc_build: Dockerfile.$(DISTRIBUTION) .build
+	docker build -f Dockerfile.$(DISTRIBUTION) --tag libdfegrpc_build:latest .
+	@touch "$@"
+
+$(LIBGRPC_RPM) $(LIBGRPC_DEVEL_RPM): Makefile.grpcdocker .build/libdfegrpc_build
+	docker run --rm -v $(CURDIR):/src:ro \
+			-v $(CURDIR):/out \
+			-e ITERATION=$(ITERATION) \
+			-e DISTRIBUTION=$(DISTRIBUTION) \
+			-e LIBGRPC_RPM=$(LIBGRPC_RPM) \
+			-e LIBGRPC_DEVEL_RPM=$(LIBGRPC_DEVEL_RPM) \
+			-w /tmp \
+			libdfegrpc_build \
+			make -f /src/Makefile.grpcdocker
+
+$(LIBDFEGRPC_RPM) $(LIBDFEGRPC_DEVEL_RPM): Makefile.dfedocker \
+	$(LIBGRPC_RPM) \
+	$(LIBGRPC_DEVEL_RPM) \
+	.build/libdfegrpc_build \
+	libdfegrpc.cc libdfegrpc.h libdfegrpc_internal.h
+	docker run --rm -v $(CURDIR):/src:ro \
+			-v $(CURDIR):/out \
+			-e VERSION=$(VERSION) \
+			-e ITERATION=$(ITERATION) \
+			-e DISTRIBUTION=$(DISTRIBUTION) \
+			-e LIBGRPC_RPM=$(LIBGRPC_RPM) \
+			-e LIBGRPC_DEVEL_RPM=$(LIBGRPC_DEVEL_RPM) \
+			-e LIBDFEGRPC_RPM=$(LIBDFEGRPC_RPM) \
+			-e LIBDFEGRPC_DEVEL_RPM=$(LIBDFEGRPC_DEVEL_RPM) \
+			-w /tmp \
+			libdfegrpc_build \
+			make -f /src/Makefile.dfedocker
+
+.PHONY: docker-test
+docker-test: docker-build
+	docker run --rm -v $(CURDIR):/src:ro \
+			-e VERSION=$(VERSION) \
+			-e COFFEE_SHOP_KEY_PATH=$(COFFEE_SHOP_KEY_PATH) \
+			-e COFFEE_SHOP_PROJECT_ID=$(COFFEE_SHOP_PROJECT_ID) \
+			libdfegrpc_build \
+			make -C /src run-test
+
+.PHONY: run-test
+run-test:
+	rpm -ivh $(RPMS)
+	dfegrpc_test_client -a coffee_please.ul -k $(COFFEE_SHOP_KEY_PATH) -p $(COFFEE_SHOP_PROJECT_ID)

--- a/Makefile.grpcdocker
+++ b/Makefile.grpcdocker
@@ -1,14 +1,16 @@
-GRPC_RELEASE ?= 1.12.1
+GRPC_RELEASE ?= 1.12.x
 PROTOBUF_RELEASE ?= 3.5.1
 
 .PHONY: all
-all: libgrpc-$(GRPC_RELEASE)-1.x86_64.rpm libgrpc-devel-$(GRPC_RELEASE)-1.x86_64.rpm
+all: $(LIBGRPC_RPM) $(LIBGRPC_DEVEL_RPM)
 	cp $^ /out
 
-libgrpc-$(GRPC_RELEASE)-1.x86_64.rpm: /usr/lib/libprotobuf.so /usr/lib/libgrpc++.so
-	fpm -s dir -t rpm -n libgrpc -v $(GRPC_RELEASE) \
+$(LIBGRPC_RPM): /usr/lib/libprotobuf.so /usr/lib/libgrpc++.so
+	fpm --input-type dir --output-type rpm --name libgrpc --version $(GRPC_RELEASE) \
 		--after-install /src/ldconfig.sh \
 		--after-upgrade /src/ldconfig.sh \
+		--rpm-dist $(DISTRIBUTION) \
+		--iteration $(ITERATION) \
 		/usr/lib/libproto* \
 		/usr/lib/libgrpc* \
 		/usr/bin/protoc \
@@ -16,9 +18,11 @@ libgrpc-$(GRPC_RELEASE)-1.x86_64.rpm: /usr/lib/libprotobuf.so /usr/lib/libgrpc++
 		/usr/bin/grpc_cpp_plugin \
 		/usr/lib/libgpr*
 
-libgrpc-devel-$(GRPC_RELEASE)-1.x86_64.rpm: /usr/lib/libprotobuf.so /usr/lib/libgrpc++.so
-	fpm -s dir -t rpm -n libgrpc-devel -v $(GRPC_RELEASE) \
-		-d 'libgrpc > 1' \
+$(LIBGRPC_DEVEL_RPM): /usr/lib/libprotobuf.so /usr/lib/libgrpc++.so
+	fpm --input-type dir --output-type rpm --name libgrpc-devel --version $(GRPC_RELEASE) \
+		--rpm-dist $(DISTRIBUTION) \
+		--iteration $(ITERATION) \
+		--depends 'libgrpc > 1' \
 		/usr/include/google/protobuf/* \
    		/usr/include/grpc*
 

--- a/install_protoc.sh
+++ b/install_protoc.sh
@@ -2,6 +2,7 @@
 
 RELEASE="v1.12.x"
 LATEST=$(curl -s -L https://grpc.io/release)
+PROTOBUF_RELEASE="3.5.1"
 
 log() {
     printf "\e[93m${1}\e[39m\n"
@@ -25,23 +26,23 @@ else
 fi
 
 pushd /tmp
-if [ ! -e protobuf-cpp-3.5.1.tar.gz ]; then
-    log "Getting protobuf-cpp-3.5.1.tar.gz"
-    wget https://github.com/google/protobuf/releases/download/v3.5.1/protobuf-cpp-3.5.1.tar.gz
+if [ ! -e protobuf-cpp-${PROTOBUF_RELEASE}.tar.gz ]; then
+    log "Getting protobuf-cpp-${PROTOBUF_RELEASE}.tar.gz"
+    wget https://github.com/google/protobuf/releases/download/v${PROTOBUF_RELEASE}/protobuf-cpp-${PROTOBUF_RELEASE}.tar.gz
 else 
     log "Protobuf release archive already downloaded"
 fi
 
-if [ ! -e protobuf-3.5.1 ]; then
+if [ ! -e protobuf-${PROTOBUF_RELEASE} ]; then
     log "Extracting protobuf source"
-    tar -x -z -f protobuf-cpp-3.5.1.tar.gz
+    tar -x -z -f protobuf-cpp-${PROTOBUF_RELEASE}.tar.gz
 else 
     log "Protobuf release archive already untarred"
 fi
 
 if [ ! -x "$(command -v protoc)" ]; then
     log "Building protobuffer..."
-    pushd protobuf-3.5.1
+    pushd protobuf-${PROTOBUF_RELEASE}
     ./configure --prefix=/usr && make && sudo make install
     popd
 else


### PR DESCRIPTION
* add EL7 Dockerfile
* upgrade ruby in dockerfiles
* split out docker build to own makefile
* modifications to existing makefiles to respect DISTRIBUTION variable and not clobber each other if being built locally in same environment
* general makefile clean-up for readability
* protoc version variable in the protoc install script
* EL6 builds by default --> `make -f Makefile.dockerbuild`
* EL7 builds with command-line DISTRIBUTION override --> `make DISTRIBUTION=el7 -f Makefile.dockerbuild`